### PR TITLE
Added Redis container

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -9,3 +9,5 @@ POSTGRES_DATABASE=zola
 POSTGRES_USER=root
 POSTGRES_PASSWORD=root
 POSTGRES_DATA_DIR=/var/lib/postgresql/data
+
+REDIS_DATA_DIR=/data

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 _pgdatadir
 dist
 coverage
+_redisdatadir/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "3001:3001"
     links:
       - "postgres:postgres.host"
+      - "redis:redis.host"
     volumes:
       - "${APP_DIR}:/zola-api:rw"
     environment:
@@ -42,3 +43,16 @@ services:
     #   options:
     #     syslog-facility: "local0"
     #     tag: "zola-postgres"
+
+
+  redis:
+    image: redis:4.0-alpine
+    container_name: "zola-redis"
+    restart: always
+    volumes:
+      - "${REDIS_DATA_DIR}:/data"
+    # logging:
+    #   driver: "syslog"
+    #   options:
+    #     syslog-facility: "local0"
+    #     tag: "zola-redis"


### PR DESCRIPTION
Added Redis container and persisted volume config.

Redis container should be reachable from Node container using redis.host. 

Note that at this moment the Redis container is not secured except for the fact that it can not be reached from anywhere but the node container.