### PR TITLE
Adding config to connect to any redis host

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -13,5 +13,6 @@ POSTGRES_PASSWORD=root
 POSTGRES_DATA_DIR=/var/lib/postgresql/data
 
 REDIS_DATA_DIR=/data
+REDIS_HOST=redis.host
 
 SENDGRID_API_KEY=

--- a/src/server/redis.js
+++ b/src/server/redis.js
@@ -6,7 +6,7 @@ import redisMock from 'redis-mock'
 const client =
   process.env.NODE_ENV === 'test'
     ? redisMock.createClient()
-    : redis.createClient()
+    : redis.createClient(process.env.REDIS_HOST || '127.0.0.1')
 client.on('error', error => console.error('Redis error:', error))
 
 const METHODS_TO_PROMISIFY = ['set', 'get', 'del']


### PR DESCRIPTION
We should be platform agnostic, and have a way for the user to override the Redis host (especially since we provide a functional docker environment in this very repo)